### PR TITLE
Update powerthesaurus.el

### DIFF
--- a/powerthesaurus.el
+++ b/powerthesaurus.el
@@ -390,8 +390,12 @@ its default value varies depending on value of QUERY-TYPE."
                       query-term query-type))))
     (with-current-buffer buf
       (dolist (elt results)
-        (insert (powerthesaurus-result-text elt) sep)))
+       (insert (powerthesaurus-result-text elt) sep)
     ;; TODO: Make buffer disposable via `keyboard-quit'.
+       (goto-char (point-min))
+       (local-set-key [backspace] 'scroll-down)
+       (local-set-key " " 'scroll-up)
+       (local-set-key (kbd "q") 'delete-window)))
     (pop-to-buffer buf)))
 
 (defun powerthesaurus--select-candidate (candidates)


### PR DESCRIPTION
I found that these additional lines 395, 396, 397, and 398 (correcting parenthesis in 393 as it's embedded in function `dolist`, line 392) will allow users to` scroll-down` and `up` and `quit` when the search is set for `sentences` and `definitions`